### PR TITLE
Fix placeholder interfering with I/O creation

### DIFF
--- a/components/dataHub/resTree.c
+++ b/components/dataHub/resTree.c
@@ -310,7 +310,7 @@ static void ReplaceResource
         // Note that this may result in lost settings. For example, Placeholders don't have
         // filter settings, but Observations do, so moving settings from an Observation to a
         // Placeholder will lose the Observation's filter settings.
-        res_MoveAdminSettings(entryRef->resourcePtr, replacementPtr);
+        res_MoveAdminSettings(entryRef->resourcePtr, replacementPtr, replacementType);
 
         // Delete the original resource.
         le_mem_Release(entryRef->resourcePtr);
@@ -549,6 +549,7 @@ resTree_EntryRef_t resTree_GetInput
     {
         // If a Namespace or Placeholder currently resides at that spot in the tree, replace it with
         // an Input.
+        // NOTE: If a new entry was created for this, it will be a Namespace entry.
         case ADMIN_ENTRY_TYPE_NAMESPACE:
         case ADMIN_ENTRY_TYPE_PLACEHOLDER:
         {

--- a/components/dataHub/resource.h
+++ b/components/dataHub/resource.h
@@ -317,7 +317,8 @@ bool res_HasAdminSettings
 void res_MoveAdminSettings
 (
     res_Resource_t* srcPtr,   ///< Move settings from this resource
-    res_Resource_t* destPtr   ///< Move settings to this resource
+    res_Resource_t* destPtr,  ///< Move settings to this resource
+    admin_EntryType_t replacementType ///< The type of the replacement resource.
 );
 
 


### PR DESCRIPTION
When a placeholder exists before an Input or Output is created,
the data type and units of the placeholder were getting copied
over the data type and units of the Input or Output.