### PR TITLE
psensor: add cpp supporting

### DIFF
--- a/components/periodicSensor/periodicSensor.h
+++ b/components/periodicSensor/periodicSensor.h
@@ -134,6 +134,9 @@ bindings:
 #ifndef PERIODIC_SENSOR_H_INCLUDE_GUARD
 #define PERIODIC_SENSOR_H_INCLUDE_GUARD
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 //--------------------------------------------------------------------------------------------------
 /**
@@ -257,5 +260,8 @@ LE_SHARED void psensor_PushJson
     const char* value
 );
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif // PERIODIC_SENSOR_H_INCLUDE_GUARD


### PR DESCRIPTION
Grove Sensor reading file is written by cpp need to integrate with datahub/psensor to create  object.