### PR TITLE
Io cleanup

### DIFF
--- a/admin.api
+++ b/admin.api
@@ -118,9 +118,10 @@
  * settings until the actual resource is created.
  *
  * If there are still configuration settings on an Input or Output when the app that created
- * it calls io_DeleteResource() to delete it, that resource will be converted into a Placeholder
- * for the configuration settings.  Only when all of those settings are removed from the
- * Placeholder will the Placeholder disappear from the resource tree.
+ * it calls io_DeleteResource() to delete it (or the client disconnects from the Data Hub),
+ * that resource will be converted into a Placeholder for the configuration settings.
+ * Only when all of those settings are removed from the Placeholder will the Placeholder
+ * disappear from the resource tree.
  *
  *
  * @subsection c_dataHubAdmin_DataSources Data Sources
@@ -451,7 +452,7 @@
  *
  * @section c_dataHubAdmin_ChangeNotifications Receiving Notifications of Resource Tree Changes
  *
- * To be notified when Resources or Observations are created or deleted, clients can register
+ * To be notified when Inputs, Outputs or Observations are created or deleted, clients can register
  * a callback:
  *  - admin_AddResourceTreeChangeHandler()
  *  - admin_RemoveResourceTreeChangeHandler()

--- a/components/adminTool/Component.cdef
+++ b/components/adminTool/Component.cdef
@@ -17,7 +17,7 @@ requires:
     {
         admin.api [manual-start]
         query.api [manual-start]
-        io.api [manual-start]
+        io.api [types-only]
     }
 
     component:

--- a/components/adminTool/tool.c
+++ b/components/adminTool/tool.c
@@ -362,12 +362,6 @@ static void ConnectToDataHub
     {
         HandleConnectionError("Data Hub Query", result);
     }
-
-    result = io_TryConnectService();
-    if (result != LE_OK)
-    {
-        HandleConnectionError("Data Hub I/O", result);
-    }
 }
 
 

--- a/components/dataHub/adminService.c
+++ b/components/dataHub/adminService.c
@@ -680,6 +680,18 @@ void admin_DeleteObs
 )
 //--------------------------------------------------------------------------------------------------
 {
+    // Verify that the path is within the /obs namespace, and if it's an absolute path, convert
+    // it into a relative path.
+    if (strncmp(path, "/obs/", 5) == 0)
+    {
+        path += 5;
+    }
+    else if (path[0] == '/')
+    {
+        LE_ERROR("Path is outside the /obs/ namespace (%s).", path);
+        return;
+    }
+
     resTree_EntryRef_t obsNamespace = resTree_FindEntry(resTree_GetRoot(), "obs");
 
     if (obsNamespace != NULL)

--- a/components/dataHub/adminService.c
+++ b/components/dataHub/adminService.c
@@ -686,7 +686,7 @@ void admin_DeleteObs
     {
         resTree_EntryRef_t entry = resTree_FindEntry(obsNamespace, path);
 
-        if (entry != NULL)
+        if ((entry != NULL) && (resTree_GetEntryType(entry) == ADMIN_ENTRY_TYPE_OBSERVATION))
         {
             resTree_DeleteObservation(entry);
         }

--- a/components/dataHub/adminService.c
+++ b/components/dataHub/adminService.c
@@ -258,7 +258,16 @@ static hub_HandlerRef_t AddPushHandler
         return NULL;
     }
 
-    return resTree_AddPushHandler(resRef, dataType, callbackPtr, contextPtr);
+    hub_HandlerRef_t handlerRef = resTree_AddPushHandler(resRef, dataType, callbackPtr, contextPtr);
+
+    // If the resource has a current value call the push handler now (if it's a data type match).
+    dataSample_Ref_t sampleRef = resTree_GetCurrentValue(resRef);
+    if (sampleRef != NULL)
+    {
+        handler_Call(handlerRef, resTree_GetDataType(resRef), sampleRef);
+    }
+
+    return handlerRef;
 }
 
 

--- a/components/dataHub/handler.c
+++ b/components/dataHub/handler.c
@@ -118,9 +118,11 @@ static void DeleteHandler
 //--------------------------------------------------------------------------------------------------
 /**
  * Remove a Handler from a given list.
+ *
+ * @return A pointer to the list that the handler was removed from, or NULL if not found.
  */
 //--------------------------------------------------------------------------------------------------
-void handler_Remove
+le_dls_List_t* handler_Remove
 (
     hub_HandlerRef_t handlerRef
 )
@@ -130,13 +132,17 @@ void handler_Remove
 
     if (handlerPtr != NULL)
     {
-        le_dls_Remove(handlerPtr->listPtr, &handlerPtr->link);
+        le_dls_List_t* listPtr = handlerPtr->listPtr;
+        le_dls_Remove(listPtr, &handlerPtr->link);
 
         DeleteHandler(handlerPtr);
+
+        return listPtr;
     }
     else
     {
         LE_ERROR("Invalid handler reference %p", handlerRef);
+        return NULL;
     }
 }
 
@@ -335,6 +341,8 @@ void handler_MoveAll
 
     while (NULL != (linkPtr = le_dls_Pop(srcListPtr)))
     {
+        Handler_t* handlerPtr = CONTAINER_OF(linkPtr, Handler_t, link);
+        handlerPtr->listPtr = destListPtr;
         le_dls_Queue(destListPtr, linkPtr);
     }
 }

--- a/components/dataHub/handler.c
+++ b/components/dataHub/handler.c
@@ -174,7 +174,6 @@ static void CallPushHandler
 )
 //--------------------------------------------------------------------------------------------------
 {
-
     if (handlerPtr->dataType == dataType)
     {
         double timestamp = dataSample_GetTimestamp(sampleRef);

--- a/components/dataHub/handler.h
+++ b/components/dataHub/handler.h
@@ -44,9 +44,11 @@ hub_HandlerRef_t handler_Add
 //--------------------------------------------------------------------------------------------------
 /**
  * Remove a Handler from whatever list it is on.
+ *
+ * @return A pointer to the list that the handler was removed from, or NULL if not found.
  */
 //--------------------------------------------------------------------------------------------------
-void handler_Remove
+le_dls_List_t* handler_Remove
 (
     hub_HandlerRef_t handlerRef
 );

--- a/components/dataHub/ioService.c
+++ b/components/dataHub/ioService.c
@@ -1218,7 +1218,8 @@ static void CleanUp
         child = nextChild;
     }
 
-    switch (resTree_GetEntryType(resource))
+    admin_EntryType_t entryType = resTree_GetEntryType(resource);
+    switch (entryType)
     {
         case ADMIN_ENTRY_TYPE_NAMESPACE:
         case ADMIN_ENTRY_TYPE_PLACEHOLDER:
@@ -1226,7 +1227,7 @@ static void CleanUp
             // These don't need to be deleted.
             // A Namespace will automatically be cleaned up when all its children go away.
             // A Placeholder should be kept until the Admin app removes all its admin settings.
-            break;
+            return;
 
         case ADMIN_ENTRY_TYPE_INPUT:
         case ADMIN_ENTRY_TYPE_OUTPUT:
@@ -1234,15 +1235,17 @@ static void CleanUp
             // If this is an Input or Output resource, delete it now.
             // This will convert it to a Placeholder if it has administrative settings.
             resTree_DeleteIO(resource);
-            break;
+            return;
 
         case ADMIN_ENTRY_TYPE_OBSERVATION:
         case ADMIN_ENTRY_TYPE_NONE:
 
             // These should never be seen in an I/O API app namespace.
             LE_FATAL("Unexpected resource type found in app's namespace.");
-            break;
+            return;
     }
+
+    LE_FATAL("Invalid resource tree entry type %d.", entryType);
 }
 
 

--- a/components/dataHub/obs.c
+++ b/components/dataHub/obs.c
@@ -1734,11 +1734,10 @@ dataSample_Ref_t obs_ApplyTransform
     dataSample_Ref_t sample = sampleRef;
     double transformVal;
 
-
     switch (obsPtr->transformType)
     {
         case OBS_TRANSFORM_TYPE_NONE:
-            break;
+            return sample;
 
         case OBS_TRANSFORM_TYPE_MEAN:
             transformVal = obs_QueryMean(resPtr, NAN);

--- a/components/dataHub/obs.c
+++ b/components/dataHub/obs.c
@@ -771,7 +771,6 @@ static dataSample_Ref_t UpdateSample
     dataSample_Ref_t sample = sampleRef;
     double timestamp = dataSample_GetTimestamp(sampleRef);
 
-
     switch (dataType)
     {
         case IO_DATA_TYPE_BOOLEAN:
@@ -1737,7 +1736,7 @@ dataSample_Ref_t obs_ApplyTransform
     switch (obsPtr->transformType)
     {
         case OBS_TRANSFORM_TYPE_NONE:
-            return sample;
+            goto done;
 
         case OBS_TRANSFORM_TYPE_MEAN:
             transformVal = obs_QueryMean(resPtr, NAN);
@@ -1760,11 +1759,10 @@ dataSample_Ref_t obs_ApplyTransform
             break;
     }
 
-    // If transformed value differs from the input sample, update the sample
-    if (OBS_TRANSFORM_TYPE_NONE != obsPtr->transformType)
-    {
-        sample = UpdateSample(sampleRef, dataType, (void *)&transformVal);
-    }
+    // Update the sample to have the new, transformed value.
+    sample = UpdateSample(sampleRef, dataType, (void *)&transformVal);
+
+done:
 
     return sample;
 }

--- a/components/dataHub/resTree.c
+++ b/components/dataHub/resTree.c
@@ -228,6 +228,7 @@ static resTree_EntryRef_t GoToEntry
     resTree_EntryRef_t currentEntry = baseNamespace;
 
     size_t i = 0;   // Index into path.
+    bool created = false; // true = a new entry object was created.
 
     while (path[i] != '\0')
     {
@@ -272,6 +273,15 @@ static resTree_EntryRef_t GoToEntry
             if (doCreate)
             {
                 childPtr = AddChild(currentEntry, entryName);
+
+                // AddChild() increments the ref count on the parent entry.
+                // If we created the parent entry, then its ref count is now too high by one.
+                if (created)
+                {
+                    le_mem_Release(currentEntry);
+                }
+
+                created = true;
             }
             else
             {
@@ -641,6 +651,7 @@ resTree_EntryRef_t resTree_GetOutput
     {
         // If a Namespace or Placeholder currently resides at that spot in the tree, replace it with
         // an Output.
+        // NOTE: If a new entry was created for this, it will be a Namespace entry.
         case ADMIN_ENTRY_TYPE_NAMESPACE:
         case ADMIN_ENTRY_TYPE_PLACEHOLDER:
         {
@@ -705,6 +716,7 @@ resTree_EntryRef_t resTree_GetObservation
 
     // If a Namespace or Placeholder currently resides at that spot in the tree, replace it with
     // an Observation.
+    // NOTE: If a new entry was created for this, it will be a Namespace entry.
     switch (entryRef->type)
     {
         case ADMIN_ENTRY_TYPE_NAMESPACE:

--- a/components/dataHub/resTree.c
+++ b/components/dataHub/resTree.c
@@ -524,9 +524,8 @@ resTree_EntryRef_t resTree_GetResource
  * If there's already a Namespace or Placeholder at the given path, it will be deleted and
  * replaced by an Input.
  *
- * @return Reference to the object, or NULL if the path is malformed, an Output or Observation
- *         already exists at that location, or an Input with different units or data type already
- *         exists at that location.
+ * @return Reference to the object, or NULL if the path is malformed or an Input, Output, or
+ *         Observation already exists at that location.
  */
 //--------------------------------------------------------------------------------------------------
 resTree_EntryRef_t resTree_GetInput
@@ -594,9 +593,8 @@ resTree_EntryRef_t resTree_GetInput
  * If there's already a Namespace or Placeholder at the given path, it will be deleted and
  * replaced by an Output.
  *
- * @return Reference to the object, or NULL if the path is malformed, an Input or Observation
- *         already exists at that location, or an Output with different units or data type already
- *         exists at that location.
+ * @return Reference to the object, or NULL if the path is malformed or an Input, Output, or
+ *         Observation already exists at that location.
  */
 //--------------------------------------------------------------------------------------------------
 resTree_EntryRef_t resTree_GetOutput
@@ -1045,7 +1043,9 @@ void resTree_DeleteIO
         le_mem_Release(ioPtr);
 
         // Release the resource tree entry.
-        // This will cause it to be removed from the resource tree.
+        // This will cause it to be removed from the resource tree, if it doesn't have any
+        // children.  If it does have children, however, then each child holds a reference
+        // count on its parent, so the parent will remain until all the children are deleted.
         le_mem_Release(entryRef);
     }
 }
@@ -1071,8 +1071,10 @@ void resTree_DeleteObservation
     obsEntry->resourcePtr = NULL;
     obsEntry->type = ADMIN_ENTRY_TYPE_NAMESPACE;
 
-    // Release the namespace (resource tree entry).  This will cause it to be removed from the
-    // resource tree.
+    // Release the namespace (resource tree entry).
+    // This will cause it to be removed from the resource tree, if it doesn't have any
+    // children.  If it does have children, however, then each child holds a reference
+    // count on its parent, so the parent will remain until all the children are deleted.
     le_mem_Release(obsEntry);
 }
 

--- a/components/dataHub/resTree.h
+++ b/components/dataHub/resTree.h
@@ -356,6 +356,17 @@ hub_HandlerRef_t resTree_AddPushHandler
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Remove a Push Handler from a resource.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_RemovePushHandler
+(
+    hub_HandlerRef_t handlerRef
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Get the current value of a resource.
  *
  * @return Reference to the Data Sample object or NULL if the resource doesn't have a current value.
@@ -424,6 +435,17 @@ void resTree_DeleteIO
  */
 //--------------------------------------------------------------------------------------------------
 void resTree_DeleteObservation
+(
+    resTree_EntryRef_t entryRef
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Delete a Namespace resource.
+ */
+//--------------------------------------------------------------------------------------------------
+void resTree_DeleteNamespace
 (
     resTree_EntryRef_t entryRef
 );

--- a/components/dataHub/resTree.h
+++ b/components/dataHub/resTree.h
@@ -218,9 +218,8 @@ resTree_EntryRef_t resTree_GetResource
  * If there's already a Namespace or Placeholder at the given path, it will be deleted and
  * replaced by an Input.
  *
- * @return Reference to the object, or NULL if the path is malformed, an Output or Observation
- *         already exists at that location, or an Input with different units or data type already
- *         exists at that location.
+ * @return Reference to the object, or NULL if the path is malformed or an Input, Output, or
+ *         Observation already exists at that location.
  */
 //--------------------------------------------------------------------------------------------------
 resTree_EntryRef_t resTree_GetInput
@@ -241,9 +240,8 @@ resTree_EntryRef_t resTree_GetInput
  * If there's already a Namespace or Placeholder at the given path, it will be deleted and
  * replaced by an Output.
  *
- * @return Reference to the object, or NULL if the path is malformed, an Input or Observation
- *         already exists at that location, or an Output with different units or data type already
- *         exists at that location.
+ * @return Reference to the object, or NULL if the path is malformed or an Input, Output, or
+ *         Observation already exists at that location.
  */
 //--------------------------------------------------------------------------------------------------
 resTree_EntryRef_t resTree_GetOutput

--- a/components/dataHub/resource.c
+++ b/components/dataHub/resource.c
@@ -759,7 +759,7 @@ void res_MoveAdminSettings
         if (srcPtr->currentValue != NULL)
         {
             // If the data type is a match for the new resource, move the current value over.
-            if (srcPtr->currentType == destPtr->currentType)
+            if (srcPtr->currentType == ioPoint_GetDataType(destPtr))
             {
                 destPtr->currentValue = srcPtr->currentValue;
                 srcPtr->currentValue = NULL; // dest took the reference count

--- a/components/dataHub/resource.h
+++ b/components/dataHub/resource.h
@@ -281,7 +281,7 @@ void res_Push
  *
  * @return Reference to the handler added.
  *
- * @note Can be removed by calling handler_Remove().
+ * @note Can be removed by calling res_RemovePushHandler().
  */
 //--------------------------------------------------------------------------------------------------
 hub_HandlerRef_t res_AddPushHandler
@@ -290,6 +290,19 @@ hub_HandlerRef_t res_AddPushHandler
     io_DataType_t dataType,
     void* callbackPtr,
     void* contextPtr
+);
+
+
+//--------------------------------------------------------------------------------------------------
+/**
+ * Remove a Push Handler from a resource.
+ *
+ * @return A reference to the resource from which the handler was removed, or NULL if not found.
+ */
+//--------------------------------------------------------------------------------------------------
+res_Resource_t* res_RemovePushHandler
+(
+    hub_HandlerRef_t handlerRef
 );
 
 
@@ -324,12 +337,13 @@ void res_MoveAdminSettings
 
 //--------------------------------------------------------------------------------------------------
 /**
- * Delete an Observation.
+ * Delete a resource.
  */
 //--------------------------------------------------------------------------------------------------
-void res_DeleteObservation
+void res_Delete
 (
-    res_Resource_t* obsPtr
+    res_Resource_t* resPtr,
+    admin_EntryType_t resourceType
 );
 
 

--- a/components/periodicSensor/periodicSensor.c
+++ b/components/periodicSensor/periodicSensor.c
@@ -197,6 +197,34 @@ static void BuildResourcePath
 
 //--------------------------------------------------------------------------------------------------
 /**
+ * Create an output resource.
+ */
+//--------------------------------------------------------------------------------------------------
+static void CreateOutput
+(
+    const char* path,   ///< Resource path at which to create the output.
+    dhubIO_DataType_t dataType, ///< Data type of the resource.
+    const char* units   ///< Units string of the resource.
+)
+//--------------------------------------------------------------------------------------------------
+{
+    le_result_t result = dhubIO_CreateOutput(path, dataType, units);
+    if (result != LE_OK)
+    {
+        if (result == LE_DUPLICATE)
+        {
+            LE_WARN("An output already existed in the Data Hub at path '%s'.", path);
+        }
+        else
+        {
+            LE_FATAL("Failed to create Data Hub output '%s' (%s).", path, LE_RESULT_TXT(result));
+        }
+    }
+}
+
+
+//--------------------------------------------------------------------------------------------------
+/**
  * Creates a periodic sensor scaffold for a sensor with a given name.
  *
  * This makes the sensor appear in the Data Hub and creates a timer for that sensor.
@@ -241,31 +269,26 @@ psensor_Ref_t psensor_Create
     le_result_t result = dhubIO_CreateInput(path, dataType, units);
     if (result != LE_OK)
     {
-        LE_FATAL("Failed to create Data Hub Input '%s' (%s).", path, LE_RESULT_TXT(result));
+        if (result == LE_DUPLICATE)
+        {
+            LE_WARN("An input already existed in the Data Hub at path '%s'.", path);
+        }
+        else
+        {
+            LE_FATAL("Failed to create Data Hub input '%s' (%s).", path, LE_RESULT_TXT(result));
+        }
     }
 
     BuildResourcePath(path, sizeof(path), sensorPtr, "enable");
-    result = dhubIO_CreateOutput(path, DHUBIO_DATA_TYPE_BOOLEAN, "");
-    if (result != LE_OK)
-    {
-        LE_FATAL("Failed to create Data Hub Output '%s' (%s).", path, LE_RESULT_TXT(result));
-    }
+    CreateOutput(path, DHUBIO_DATA_TYPE_BOOLEAN, "");
     sensorPtr->enableHandlerRef = dhubIO_AddBooleanPushHandler(path, HandleEnablePush, sensorPtr);
 
     BuildResourcePath(path, sizeof(path), sensorPtr, "period");
-    result = dhubIO_CreateOutput(path, DHUBIO_DATA_TYPE_NUMERIC, "s");
-    if (result != LE_OK)
-    {
-        LE_FATAL("Failed to create Data Hub Output '%s' (%s).", path, LE_RESULT_TXT(result));
-    }
+    CreateOutput(path, DHUBIO_DATA_TYPE_NUMERIC, "s");
     sensorPtr->periodHandlerRef = dhubIO_AddNumericPushHandler(path, HandlePeriodPush, sensorPtr);
 
     BuildResourcePath(path, sizeof(path), sensorPtr, "trigger");
-    result = dhubIO_CreateOutput(path, DHUBIO_DATA_TYPE_TRIGGER, "");
-    if (result != LE_OK)
-    {
-        LE_FATAL("Failed to create Data Hub Output '%s' (%s).", path, LE_RESULT_TXT(result));
-    }
+    CreateOutput(path, DHUBIO_DATA_TYPE_TRIGGER, "");
     sensorPtr->triggerHandlerRef = dhubIO_AddTriggerPushHandler(path, HandleTriggerPush, sensorPtr);
     dhubIO_MarkOptional(path);
 

--- a/dataHub.adef
+++ b/dataHub.adef
@@ -42,13 +42,11 @@ extern:
 
     dhubToolAdmin = dhub.adminTool.admin
     dhubToolQuery = dhub.adminTool.query
-    dhubToolIo = dhub.adminTool.io
 }
 
 bindings:
 {
     dhub.adminTool.admin -> hubd.dataHub.admin
     dhub.adminTool.query -> hubd.dataHub.query
-    dhub.adminTool.io -> hubd.dataHub.io
     hubd.dataHub.le_appInfo -> <root>.le_appInfo
 }


### PR DESCRIPTION
The main purpose of these commits is to clean up I/O resources when the client that owns them disconnects.  This is a feature that just hadn't been implemented yet.

But I also changed the behaviour of the Admin API's "Add Push Handler" functions to make them consistent with the behaviour of the Query and I/O APIs' "Add Push Handler" functions.  It now calls the handler function immediately with the current value when the push handler is added, if there is a current value.

I also made a few documentation fixes and cleaned up some minor stuff.