### PR TITLE
Check for NaN

### DIFF
--- a/components/periodicSensor/periodicSensor.c
+++ b/components/periodicSensor/periodicSensor.c
@@ -113,7 +113,7 @@ static void HandlePeriodPush
     {
         // Sanity check the period.
         // If it's invalid, stop the timer and set the period to 0.0.
-        if (period <= 0.0)
+        if ((period <= 0.0) || isnan(period))
         {
             LE_ERROR("Timer period %lf is out of range. Must be > 0.", period);
             le_timer_Stop(sensorPtr->timer);


### PR DESCRIPTION
Checks for floating point "not a number" in periodic sensor's period configuration, and handles it gracefully (same as if it were zero).